### PR TITLE
Add day and night brightness settings

### DIFF
--- a/patches/gsd-3.22-color-Add-ability-to-change-the-color-temperature-of.patch
+++ b/patches/gsd-3.22-color-Add-ability-to-change-the-color-temperature-of.patch
@@ -1,8 +1,8 @@
-From f81dacbb7982a66cb58facd93eabe300b6ed202b Mon Sep 17 00:00:00 2001
+From 22ff87d414e97a8be0b464186cfe205a35e2b720 Mon Sep 17 00:00:00 2001
 From: Benjamin Berg <benjamin@sipsolutions.net>
-Date: Sat, 19 Nov 2016 22:57:48 +0100
-Subject: [PATCH] color: Add ability to change the color temperature of the
- display
+Date: Wed, 18 Jan 2017 21:37:42 -0500
+Subject: [PATCH] color: Add ability to change the color temperature and
+brightness of the display
 
 This is an experimental feature which allows the color temperature to be
 changed while still keeping further gamma correction active.
@@ -12,20 +12,20 @@ This should be used with the experimental redshift extension from:
 
 Signed-off-by: Benjamin Berg <benjamin@sipsolutions.net>
 ---
- ...settings-daemon.plugins.color.gschema.xml.in.in |  11 +
+ ...settings-daemon.plugins.color.gschema.xml.in.in |  17 ++
  plugins/color/Makefile.am                          |   4 +-
  plugins/color/colorramp.c                          | 308 +++++++++++++++++++++
  plugins/color/colorramp.h                          |  27 ++
- plugins/color/gsd-color-state.c                    |  69 ++++-
- 5 files changed, 409 insertions(+), 10 deletions(-)
+ plugins/color/gsd-color-state.c                    |  84 +++++-
+ 5 files changed, 429 insertions(+), 11 deletions(-)
  create mode 100644 plugins/color/colorramp.c
  create mode 100644 plugins/color/colorramp.h
 
 diff --git a/data/org.gnome.settings-daemon.plugins.color.gschema.xml.in.in b/data/org.gnome.settings-daemon.plugins.color.gschema.xml.in.in
-index e5bf62c..6b027ff 100644
+index e5bf62c6..e658686d 100644
 --- a/data/org.gnome.settings-daemon.plugins.color.gschema.xml.in.in
 +++ b/data/org.gnome.settings-daemon.plugins.color.gschema.xml.in.in
-@@ -20,5 +20,16 @@
+@@ -20,5 +20,22 @@
        <_summary>The duration a printer profile is valid</_summary>
        <_description>This is the number of days after which the printer color profile is considered invalid.</_description>
      </key>
@@ -40,10 +40,16 @@ index e5bf62c..6b027ff 100644
 +      <_summary>The color temperature of the displays</_summary>
 +      <_description>The color temperature of all displays that have a color profile is adjusted. A value of 6500 Kelvin is an identify transformation.</_description>
 +    </key>
++    <key name="color-brightness" type="d">
++      <default>1.0</default>
++      <range min="0.1" max="1.0"/>
++      <_summary>The color brightness of the displays</_summary>
++      <_description>The color brightness of all displays that have a color profile is adjusted. Maximum standard brightness is 1.0.</_description>
++    </key>
    </schema>
  </schemalist>
 diff --git a/plugins/color/Makefile.am b/plugins/color/Makefile.am
-index 0f7497a..e15913d 100644
+index 0f7497a9..e15913d2 100644
 --- a/plugins/color/Makefile.am
 +++ b/plugins/color/Makefile.am
 @@ -14,7 +14,9 @@ libcolor_la_SOURCES = 			\
@@ -59,7 +65,7 @@ index 0f7497a..e15913d 100644
  	-I$(top_srcdir)/gnome-settings-daemon		\
 diff --git a/plugins/color/colorramp.c b/plugins/color/colorramp.c
 new file mode 100644
-index 0000000..a4949d6
+index 00000000..1b4f297c
 --- /dev/null
 +++ b/plugins/color/colorramp.c
 @@ -0,0 +1,308 @@
@@ -346,7 +352,7 @@ index 0000000..a4949d6
 +}
 +
 +void
-+colorramp_get_factor(int to_temp, double *r, double *g, double *b)
++colorramp_get_factor(int to_temp, double brightness, double *r, double *g, double *b)
 +{
 +	/* Approximate white point */
 +	float white_point[3];
@@ -367,13 +373,13 @@ index 0000000..a4949d6
 +	interpolate_color(alpha, &blackbody_color[temp_index],
 +			  &blackbody_color[temp_index+3], white_point);
 +
-+	*r = white_point[0];
-+	*g = white_point[1];
-+	*b = white_point[2];
++	*r = brightness * white_point[0];
++	*g = brightness * white_point[1];
++	*b = brightness * white_point[2];
 +}
 diff --git a/plugins/color/colorramp.h b/plugins/color/colorramp.h
 new file mode 100644
-index 0000000..436d736
+index 00000000..fcc32e8f
 --- /dev/null
 +++ b/plugins/color/colorramp.h
 @@ -0,0 +1,27 @@
@@ -401,11 +407,11 @@ index 0000000..436d736
 +
 +#include <stdint.h>
 +
-+void colorramp_get_factor(int to_temp, double *r, double *g, double *b);
++void colorramp_get_factor(int to_temp, double brightness, double *r, double *g, double *b);
 +
 +#endif /* ! REDSHIFT_COLORRAMP_H */
 diff --git a/plugins/color/gsd-color-state.c b/plugins/color/gsd-color-state.c
-index 9f8308f..5ab4337 100644
+index 9f8308f8..a2f86d9f 100644
 --- a/plugins/color/gsd-color-state.c
 +++ b/plugins/color/gsd-color-state.c
 @@ -27,6 +27,7 @@
@@ -429,25 +435,26 @@ index 9f8308f..5ab4337 100644
  struct GsdColorStatePrivate
  {
          GCancellable    *cancellable;
-@@ -53,6 +58,8 @@ struct GsdColorStatePrivate
+@@ -53,6 +58,9 @@ struct GsdColorStatePrivate
          GdkWindow       *gdk_window;
          gboolean         session_is_active;
          GHashTable      *device_assign_hash;
 +        gint            color_temperature;
++        gdouble         color_brightness;
 +        GSettings       *settings;
  };
  
  static void     gsd_color_state_class_init  (GsdColorStateClass *klass);
-@@ -360,7 +367,7 @@ out:
+@@ -360,7 +368,7 @@ out:
  }
  
  static GPtrArray *
 -gcm_session_generate_vcgt (CdProfile *profile, guint size)
-+gcm_session_generate_vcgt (CdProfile *profile, gint color_temperature, guint size)
++gcm_session_generate_vcgt (CdProfile *profile, gint color_temperature, gdouble color_brightness, guint size)
  {
          GnomeRROutputClutItem *tmp;
          GPtrArray *array = NULL;
-@@ -369,6 +376,7 @@ gcm_session_generate_vcgt (CdProfile *profile, guint size)
+@@ -369,6 +377,7 @@ gcm_session_generate_vcgt (CdProfile *profile, guint size)
          guint i;
          cmsHPROFILE lcms_profile;
          CdIcc *icc = NULL;
@@ -455,11 +462,11 @@ index 9f8308f..5ab4337 100644
  
          /* invalid size */
          if (size == 0)
-@@ -387,14 +395,16 @@ gcm_session_generate_vcgt (CdProfile *profile, guint size)
+@@ -387,14 +396,16 @@ gcm_session_generate_vcgt (CdProfile *profile, guint size)
                  goto out;
          }
  
-+        colorramp_get_factor(color_temperature, &r, &g, &b);
++        colorramp_get_factor(color_temperature, color_brightness, &r, &g, &b);
 +
          /* create array */
          array = g_ptr_array_new_with_free_func (g_free);
@@ -475,33 +482,36 @@ index 9f8308f..5ab4337 100644
                  g_ptr_array_add (array, tmp);
          }
  out:
-@@ -475,6 +485,7 @@ out:
+@@ -475,6 +486,8 @@ out:
  static gboolean
  gcm_session_device_set_gamma (GnomeRROutput *output,
                                CdProfile *profile,
 +                              gint color_temperature,
++                              gdouble color_brightness,
                                GError **error)
  {
          gboolean ret = FALSE;
-@@ -487,7 +498,7 @@ gcm_session_device_set_gamma (GnomeRROutput *output,
+@@ -487,7 +500,7 @@ gcm_session_device_set_gamma (GnomeRROutput *output,
                  ret = TRUE;
                  goto out;
          }
 -        clut = gcm_session_generate_vcgt (profile, size);
-+        clut = gcm_session_generate_vcgt (profile, color_temperature, size);
++        clut = gcm_session_generate_vcgt (profile, color_temperature, color_brightness, size);
          if (clut == NULL) {
                  g_set_error_literal (error,
                                       GSD_COLOR_MANAGER_ERROR,
-@@ -507,7 +518,7 @@ out:
+@@ -507,8 +520,8 @@ out:
  }
  
  static gboolean
 -gcm_session_device_reset_gamma (GnomeRROutput *output,
+-                                GError **error)
 +gcm_session_device_reset_gamma (GnomeRROutput *output, gint color_temperature,
-                                 GError **error)
++                                gdouble color_brightness, GError **error)
  {
          gboolean ret;
-@@ -516,6 +527,7 @@ gcm_session_device_reset_gamma (GnomeRROutput *output,
+         guint i;
+@@ -516,6 +529,7 @@ gcm_session_device_reset_gamma (GnomeRROutput *output,
          guint32 value;
          GPtrArray *clut;
          GnomeRROutputClutItem *data;
@@ -509,12 +519,12 @@ index 9f8308f..5ab4337 100644
  
          /* create a linear ramp */
          g_debug ("falling back to dummy ramp");
-@@ -525,12 +537,15 @@ gcm_session_device_reset_gamma (GnomeRROutput *output,
+@@ -525,12 +539,15 @@ gcm_session_device_reset_gamma (GnomeRROutput *output,
                  ret = TRUE;
                  goto out;
          }
 +
-+        colorramp_get_factor(color_temperature, &r, &g, &b);
++        colorramp_get_factor(color_temperature, color_brightness, &r, &g, &b);
 +
          for (i = 0; i < size; i++) {
                  value = (i * 0xffff) / (size - 1);
@@ -528,7 +538,7 @@ index 9f8308f..5ab4337 100644
                  g_ptr_array_add (clut, data);
          }
  
-@@ -669,6 +684,7 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
+@@ -669,6 +686,7 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
          guint brightness_percentage;
          GcmSessionAsyncHelper *helper = (GcmSessionAsyncHelper *) user_data;
          GsdColorState *state = GSD_COLOR_STATE (helper->state);
@@ -536,31 +546,34 @@ index 9f8308f..5ab4337 100644
  
          /* get properties */
          ret = cd_profile_connect_finish (profile, res, &error);
-@@ -720,6 +736,7 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
+@@ -720,6 +738,8 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
          if (ret) {
                  ret = gcm_session_device_set_gamma (output,
                                                      profile,
 +                                                    priv->color_temperature,
++                                                    priv->color_brightness,
                                                      &error);
                  if (!ret) {
                          g_warning ("failed to set %s gamma tables: %s",
-@@ -730,6 +747,7 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
+@@ -730,6 +750,8 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
                  }
          } else {
                  ret = gcm_session_device_reset_gamma (output,
 +                                                      priv->color_temperature,
++                                                      priv->color_brightness,
                                                        &error);
                  if (!ret) {
                          g_warning ("failed to reset %s gamma tables: %s",
-@@ -874,6 +892,7 @@ gcm_session_device_assign_connect_cb (GObject *object,
+@@ -874,6 +896,8 @@ gcm_session_device_assign_connect_cb (GObject *object,
  
                  /* reset, as we want linear profiles for profiling */
                  ret = gcm_session_device_reset_gamma (output,
 +                                                      priv->color_temperature,
++                                                      priv->color_brightness,
                                                        &error);
                  if (!ret) {
                          g_warning ("failed to reset %s gamma tables: %s",
-@@ -1359,6 +1378,25 @@ out:
+@@ -1359,6 +1383,29 @@ out:
  }
  
  static void
@@ -568,12 +581,16 @@ index 9f8308f..5ab4337 100644
 +                                const gchar *key,
 +                                GsdColorState *state)
 +{
-+        if (g_str_equal (key, "color-temperature") || g_str_equal (key, "adjust-color-temperature")) {
++        if (g_str_equal (key, "color-temperature") || g_str_equal (key, "color-brightness") ||
++        g_str_equal (key, "adjust-color-temperature")) {
 +                if (g_settings_get_boolean (state->priv->settings, "adjust-color-temperature")) {
 +                        state->priv->color_temperature = g_settings_get_int (state->priv->settings,
 +                                                                              "color-temperature");
++                        state->priv->color_brightness = g_settings_get_double (state->priv->settings,
++                                                                              "color-brightness");
 +                } else {
 +                        state->priv->color_temperature = -1;
++                        state->priv->color_brightness = 1.0;
 +                }
 +
 +                /* Emulate a screen change event. */
@@ -586,7 +603,7 @@ index 9f8308f..5ab4337 100644
  on_rr_screen_acquired (GObject      *object,
                         GAsyncResult *result,
                         gpointer      data)
-@@ -1404,6 +1442,18 @@ gsd_color_state_start (GsdColorState *state)
+@@ -1404,6 +1451,21 @@ gsd_color_state_start (GsdColorState *state)
          gnome_rr_screen_new_async (gdk_screen_get_default (),
                                     on_rr_screen_acquired,
                                     g_object_ref (state));
@@ -599,20 +616,24 @@ index 9f8308f..5ab4337 100644
 +        if (g_settings_get_boolean (state->priv->settings, "adjust-color-temperature")) {
 +                state->priv->color_temperature = g_settings_get_int (state->priv->settings,
 +                                                                      "color-temperature");
++                state->priv->color_brightness = g_settings_get_double (state->priv->settings,
++                                                                      "color-brightness");
 +        } else {
 +                state->priv->color_temperature = -1;
++                state->priv->color_brightness = 1.0;
 +        }
  }
  
  void
-@@ -1431,6 +1481,7 @@ gsd_color_state_init (GsdColorState *state)
+@@ -1431,6 +1493,8 @@ gsd_color_state_init (GsdColorState *state)
  
          /* track the active session */
          priv->session = gnome_settings_bus_get_session_proxy ();
 +        priv->color_temperature = -1;
++        priv->color_brightness = 1.0;
  
  #ifdef GDK_WINDOWING_X11
          /* set the _ICC_PROFILE atoms on the root screen */
 -- 
-2.10.2
+2.11.0
 

--- a/patches/gsd-master-color-Add-ability-to-change-the-color-temperature-of.patch
+++ b/patches/gsd-master-color-Add-ability-to-change-the-color-temperature-of.patch
@@ -1,8 +1,8 @@
-From 460f7344c042a99c4c7e3b6912f009858e27ffc9 Mon Sep 17 00:00:00 2001
+From 59bf9e7fa537f6086f33915826a6aaef56267f80 Mon Sep 17 00:00:00 2001
 From: Benjamin Berg <benjamin@sipsolutions.net>
-Date: Sat, 19 Nov 2016 22:57:48 +0100
-Subject: [PATCH] color: Add ability to change the color temperature of the
- display
+Date: Wed, 18 Jan 2017 21:37:42 -0500
+Subject: [PATCH] color: Add ability to change the color temperature and
+brightness of the display
 
 This is an experimental feature which allows the color temperature to be
 changed while still keeping further gamma correction active.
@@ -12,20 +12,20 @@ This should be used with the experimental redshift extension from:
 
 Signed-off-by: Benjamin Berg <benjamin@sipsolutions.net>
 ---
- ...settings-daemon.plugins.color.gschema.xml.in.in |  11 +
+ ...settings-daemon.plugins.color.gschema.xml.in.in |  17 ++
  plugins/color/Makefile.am                          |   2 +
  plugins/color/colorramp.c                          | 308 +++++++++++++++++++++
  plugins/color/colorramp.h                          |  27 ++
- plugins/color/gsd-color-state.c                    |  68 ++++-
- 5 files changed, 407 insertions(+), 9 deletions(-)
+ plugins/color/gsd-color-state.c                    |  82 +++++-
+ 5 files changed, 426 insertions(+), 10 deletions(-)
  create mode 100644 plugins/color/colorramp.c
  create mode 100644 plugins/color/colorramp.h
 
 diff --git a/data/org.gnome.settings-daemon.plugins.color.gschema.xml.in.in b/data/org.gnome.settings-daemon.plugins.color.gschema.xml.in.in
-index 3df07c7..4713b09 100644
+index 3df07c75..1e586129 100644
 --- a/data/org.gnome.settings-daemon.plugins.color.gschema.xml.in.in
 +++ b/data/org.gnome.settings-daemon.plugins.color.gschema.xml.in.in
-@@ -10,5 +10,16 @@
+@@ -10,5 +10,22 @@
        <_summary>The duration a printer profile is valid</_summary>
        <_description>This is the number of days after which the printer color profile is considered invalid.</_description>
      </key>
@@ -40,10 +40,16 @@ index 3df07c7..4713b09 100644
 +      <_summary>The color temperature of the displays</_summary>
 +      <_description>The color temperature of all displays that have a color profile is adjusted. A value of 6500 Kelvin is an identify transformation.</_description>
 +    </key>
++    <key name="color-brightness" type="d">
++      <default>1.0</default>
++      <range min="0.1" max="1.0"/>
++      <_summary>The color brightness of the displays</_summary>
++      <_description>The color brightness of all displays that have a color profile is adjusted. Maximum standard brightness is 1.0.</_description>
++    </key>
    </schema>
  </schemalist>
 diff --git a/plugins/color/Makefile.am b/plugins/color/Makefile.am
-index 8fc729a..416ba25 100644
+index 8fc729ad..416ba25d 100644
 --- a/plugins/color/Makefile.am
 +++ b/plugins/color/Makefile.am
 @@ -37,6 +37,8 @@ gsd_color_SOURCES =			\
@@ -57,7 +63,7 @@ index 8fc729a..416ba25 100644
  gsd_color_CFLAGS =			\
 diff --git a/plugins/color/colorramp.c b/plugins/color/colorramp.c
 new file mode 100644
-index 0000000..a4949d6
+index 00000000..1b4f297c
 --- /dev/null
 +++ b/plugins/color/colorramp.c
 @@ -0,0 +1,308 @@
@@ -344,7 +350,7 @@ index 0000000..a4949d6
 +}
 +
 +void
-+colorramp_get_factor(int to_temp, double *r, double *g, double *b)
++colorramp_get_factor(int to_temp, double brightness, double *r, double *g, double *b)
 +{
 +	/* Approximate white point */
 +	float white_point[3];
@@ -365,13 +371,13 @@ index 0000000..a4949d6
 +	interpolate_color(alpha, &blackbody_color[temp_index],
 +			  &blackbody_color[temp_index+3], white_point);
 +
-+	*r = white_point[0];
-+	*g = white_point[1];
-+	*b = white_point[2];
++	*r = brightness * white_point[0];
++	*g = brightness * white_point[1];
++	*b = brightness * white_point[2];
 +}
 diff --git a/plugins/color/colorramp.h b/plugins/color/colorramp.h
 new file mode 100644
-index 0000000..436d736
+index 00000000..fcc32e8f
 --- /dev/null
 +++ b/plugins/color/colorramp.h
 @@ -0,0 +1,27 @@
@@ -399,22 +405,14 @@ index 0000000..436d736
 +
 +#include <stdint.h>
 +
-+void colorramp_get_factor(int to_temp, double *r, double *g, double *b);
++void colorramp_get_factor(int to_temp, double brightness, double *r, double *g, double *b);
 +
 +#endif /* ! REDSHIFT_COLORRAMP_H */
 diff --git a/plugins/color/gsd-color-state.c b/plugins/color/gsd-color-state.c
-index 8778a44..36f343d 100644
+index 8778a44f..c3deb299 100644
 --- a/plugins/color/gsd-color-state.c
 +++ b/plugins/color/gsd-color-state.c
-@@ -27,6 +27,7 @@
- #include <lcms2.h>
- #include <canberra-gtk.h>
- 
-+
- #define GNOME_DESKTOP_USE_UNSTABLE_API
- #include <libgnome-desktop/gnome-rr.h>
- 
-@@ -40,11 +41,14 @@
+@@ -40,11 +40,14 @@
  #include "gsd-color-state.h"
  #include "gcm-edid.h"
  
@@ -429,11 +427,12 @@ index 8778a44..36f343d 100644
  
  struct GsdColorStatePrivate
  {
-@@ -56,6 +60,8 @@ struct GsdColorStatePrivate
+@@ -56,6 +59,9 @@ struct GsdColorStatePrivate
          GdkWindow       *gdk_window;
          gboolean         session_is_active;
          GHashTable      *device_assign_hash;
 +        gint            color_temperature;
++        gdouble         color_brightness;
 +        GSettings       *settings;
  };
  
@@ -443,7 +442,7 @@ index 8778a44..36f343d 100644
  
  static GPtrArray *
 -gcm_session_generate_vcgt (CdProfile *profile, guint size)
-+gcm_session_generate_vcgt (CdProfile *profile, gint color_temperature, guint size)
++gcm_session_generate_vcgt (CdProfile *profile, gint color_temperature, gdouble color_brightness, guint size)
  {
          GnomeRROutputClutItem *tmp;
          GPtrArray *array = NULL;
@@ -459,7 +458,7 @@ index 8778a44..36f343d 100644
                  goto out;
          }
  
-+        colorramp_get_factor(color_temperature, &r, &g, &b);
++        colorramp_get_factor(color_temperature, color_brightness, &r, &g, &b);
 +
          /* create array */
          array = g_ptr_array_new_with_free_func (g_free);
@@ -475,33 +474,36 @@ index 8778a44..36f343d 100644
                  g_ptr_array_add (array, tmp);
          }
  out:
-@@ -475,6 +484,7 @@ out:
+@@ -475,6 +484,8 @@ out:
  static gboolean
  gcm_session_device_set_gamma (GnomeRROutput *output,
                                CdProfile *profile,
 +                              gint color_temperature,
++                              gdouble color_brightness,
                                GError **error)
  {
          gboolean ret = FALSE;
-@@ -487,7 +497,7 @@ gcm_session_device_set_gamma (GnomeRROutput *output,
+@@ -487,7 +498,7 @@ gcm_session_device_set_gamma (GnomeRROutput *output,
                  ret = TRUE;
                  goto out;
          }
 -        clut = gcm_session_generate_vcgt (profile, size);
-+        clut = gcm_session_generate_vcgt (profile, color_temperature, size);
++        clut = gcm_session_generate_vcgt (profile, color_temperature, color_brightness, size);
          if (clut == NULL) {
                  g_set_error_literal (error,
                                       GSD_COLOR_MANAGER_ERROR,
-@@ -507,7 +517,7 @@ out:
+@@ -507,8 +518,8 @@ out:
  }
  
  static gboolean
 -gcm_session_device_reset_gamma (GnomeRROutput *output,
+-                                GError **error)
 +gcm_session_device_reset_gamma (GnomeRROutput *output, gint color_temperature,
-                                 GError **error)
++                                gdouble color_brightness, GError **error)
  {
          gboolean ret;
-@@ -516,6 +526,7 @@ gcm_session_device_reset_gamma (GnomeRROutput *output,
+         guint i;
+@@ -516,6 +527,7 @@ gcm_session_device_reset_gamma (GnomeRROutput *output,
          guint32 value;
          GPtrArray *clut;
          GnomeRROutputClutItem *data;
@@ -509,12 +511,12 @@ index 8778a44..36f343d 100644
  
          /* create a linear ramp */
          g_debug ("falling back to dummy ramp");
-@@ -525,12 +536,15 @@ gcm_session_device_reset_gamma (GnomeRROutput *output,
+@@ -525,12 +537,15 @@ gcm_session_device_reset_gamma (GnomeRROutput *output,
                  ret = TRUE;
                  goto out;
          }
 +
-+        colorramp_get_factor(color_temperature, &r, &g, &b);
++        colorramp_get_factor(color_temperature, color_brightness, &r, &g, &b);
 +
          for (i = 0; i < size; i++) {
                  value = (i * 0xffff) / (size - 1);
@@ -528,7 +530,7 @@ index 8778a44..36f343d 100644
                  g_ptr_array_add (clut, data);
          }
  
-@@ -669,6 +683,7 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
+@@ -669,6 +684,7 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
          guint brightness_percentage;
          GcmSessionAsyncHelper *helper = (GcmSessionAsyncHelper *) user_data;
          GsdColorState *state = GSD_COLOR_STATE (helper->state);
@@ -536,31 +538,34 @@ index 8778a44..36f343d 100644
  
          /* get properties */
          ret = cd_profile_connect_finish (profile, res, &error);
-@@ -720,6 +735,7 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
+@@ -720,6 +736,8 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
          if (ret) {
                  ret = gcm_session_device_set_gamma (output,
                                                      profile,
 +                                                    priv->color_temperature,
++                                                    priv->color_brightness,
                                                      &error);
                  if (!ret) {
                          g_warning ("failed to set %s gamma tables: %s",
-@@ -730,6 +746,7 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
+@@ -730,6 +748,8 @@ gcm_session_device_assign_profile_connect_cb (GObject *object,
                  }
          } else {
                  ret = gcm_session_device_reset_gamma (output,
 +                                                      priv->color_temperature,
++                                                      priv->color_brightness,
                                                        &error);
                  if (!ret) {
                          g_warning ("failed to reset %s gamma tables: %s",
-@@ -874,6 +891,7 @@ gcm_session_device_assign_connect_cb (GObject *object,
+@@ -874,6 +894,8 @@ gcm_session_device_assign_connect_cb (GObject *object,
  
                  /* reset, as we want linear profiles for profiling */
                  ret = gcm_session_device_reset_gamma (output,
 +                                                      priv->color_temperature,
++                                                      priv->color_brightness,
                                                        &error);
                  if (!ret) {
                          g_warning ("failed to reset %s gamma tables: %s",
-@@ -1357,6 +1375,25 @@ gcm_session_client_connect_cb (GObject *source_object,
+@@ -1357,6 +1379,29 @@ gcm_session_client_connect_cb (GObject *source_object,
  }
  
  static void
@@ -568,12 +573,16 @@ index 8778a44..36f343d 100644
 +                                const gchar *key,
 +                                GsdColorState *state)
 +{
-+        if (g_str_equal (key, "color-temperature") || g_str_equal (key, "adjust-color-temperature")) {
++        if (g_str_equal (key, "color-temperature") || g_str_equal (key, "color-brightness") ||
++        g_str_equal (key, "adjust-color-temperature")) {
 +                if (g_settings_get_boolean (state->priv->settings, "adjust-color-temperature")) {
 +                        state->priv->color_temperature = g_settings_get_int (state->priv->settings,
 +                                                                              "color-temperature");
++                        state->priv->color_brightness = g_settings_get_double (state->priv->settings,
++                                                                              "color-brightness");
 +                } else {
 +                        state->priv->color_temperature = -1;
++                        state->priv->color_brightness = 1.0;
 +                }
 +
 +                /* Emulate a screen change event. */
@@ -586,7 +595,7 @@ index 8778a44..36f343d 100644
  on_rr_screen_acquired (GObject      *object,
                         GAsyncResult *result,
                         gpointer      data)
-@@ -1402,6 +1439,18 @@ gsd_color_state_start (GsdColorState *state)
+@@ -1402,6 +1447,21 @@ gsd_color_state_start (GsdColorState *state)
          gnome_rr_screen_new_async (gdk_screen_get_default (),
                                     on_rr_screen_acquired,
                                     g_object_ref (state));
@@ -599,20 +608,24 @@ index 8778a44..36f343d 100644
 +        if (g_settings_get_boolean (state->priv->settings, "adjust-color-temperature")) {
 +                state->priv->color_temperature = g_settings_get_int (state->priv->settings,
 +                                                                      "color-temperature");
++                state->priv->color_brightness = g_settings_get_double (state->priv->settings,
++                                                                      "color-brightness");
 +        } else {
 +                state->priv->color_temperature = -1;
++                state->priv->color_brightness = 1.0;
 +        }
  }
  
  void
-@@ -1429,6 +1478,7 @@ gsd_color_state_init (GsdColorState *state)
+@@ -1429,6 +1489,8 @@ gsd_color_state_init (GsdColorState *state)
  
          /* track the active session */
          priv->session = gnome_settings_bus_get_session_proxy ();
 +        priv->color_temperature = -1;
++        priv->color_brightness = 1.0;
  
  #ifdef GDK_WINDOWING_X11
          /* set the _ICC_PROFILE atoms on the root screen */
 -- 
-2.10.2
+2.11.0
 

--- a/redshift@benjamin.sipsolutions.net/extension.js
+++ b/redshift@benjamin.sipsolutions.net/extension.js
@@ -132,6 +132,13 @@ const Redshift = new Lang.Class({
 
         this._color_settings.set_int("color-temperature", temp);
 
+        let night_brt = this._settings.get_double(Lib.NIGHT_BRT_KEY);
+        let day_brt = this._settings.get_double(Lib.DAY_BRT_KEY);
+
+        let brt = night_brt * (1 - night_day) + day_brt * night_day;
+
+        this._color_settings.set_double("color-brightness", brt);
+
         if (enabled) {
             if (night_day < 0.1) {
                 this._icon.icon_name = "my-redshift-moon-symbolic";

--- a/redshift@benjamin.sipsolutions.net/lib.js
+++ b/redshift@benjamin.sipsolutions.net/lib.js
@@ -22,6 +22,8 @@ const SHOW_INDICATOR_KEY = 'show-indicator';
 const STATE_KEY = 'state';
 const NIGHT_TEMP_KEY = 'night-color-temperature';
 const DAY_TEMP_KEY = 'day-color-temperature';
+const NIGHT_BRT_KEY = 'night-brightness'
+const DAY_BRT_KEY = 'day-brightness'
 const NIGHT_DAY_KEY = 'night-day';
 const DUSK_DAWN_LENGTH_KEY = 'dusk-dawn-length';
 

--- a/redshift@benjamin.sipsolutions.net/locale/messages.pot
+++ b/redshift@benjamin.sipsolutions.net/locale/messages.pot
@@ -41,6 +41,14 @@ msgstr ""
 msgid "Nighttime color temperature (e.g.: 2750K)"
 msgstr ""
 
-#: prefs.js:75
+#: prefs.js:76
+msgid "Daytime brightness (full: 1.0)"
+msgstr ""
+
+#: prefs.js:91
+msgid "Nighttime brightness (e.g.: 0.5)"
+msgstr ""
+
+#: prefs.js:107
 msgid "Length of the dusk/dawn progression in minutes"
 msgstr ""

--- a/redshift@benjamin.sipsolutions.net/prefs.js
+++ b/redshift@benjamin.sipsolutions.net/prefs.js
@@ -72,6 +72,38 @@ const RedshiftWidget = new Lang.Class({
         this.w.attach(label, 0, 3, 1, 1);
         this.w.attach(temp, 1, 3, 1, 1);
 
+
+         let label = new Gtk.Label({label: _("Daytime brightness (full: 1.0)"),
+                                           xalign: 0});
+
+        let temp = new Gtk.SpinButton();
+        temp.set_range(0.1, 1.0);
+        temp.set_value(this._settings.get_double(Lib.DAY_BRT_KEY));
+        temp.set_digits(1);
+        temp.set_increments(0.1, 0.5);
+        temp.connect('notify::value', Lang.bind(this, function(button) {
+            this._settings.set_double(Lib.DAY_BRT_KEY, button.value);
+        }));
+
+        this.w.attach(label, 0, 4, 1, 1);
+        this.w.attach(temp, 1, 4, 1, 1);
+
+        let label = new Gtk.Label({label: _("Nighttime brightness (e.g.: 0.5)"),
+                                           xalign: 0});
+
+        let temp = new Gtk.SpinButton();
+        temp.set_range(0.1, 1.0);
+        temp.set_value(this._settings.get_double(Lib.NIGHT_BRT_KEY));
+        temp.set_digits(1);
+        temp.set_increments(0.1, 0.5);
+        temp.connect('notify::value', Lang.bind(this, function(button) {
+            this._settings.set_double(Lib.NIGHT_BRT_KEY, button.value);
+        }));
+   
+
+        this.w.attach(label, 0, 5, 1, 1);
+        this.w.attach(temp, 1, 5, 1, 1);
+
         let label = new Gtk.Label({label: _("Length of the dusk/dawn progression in minutes"),
                                            xalign: 0});
 
@@ -84,8 +116,8 @@ const RedshiftWidget = new Lang.Class({
             this._settings.set_uint(Lib.DUSK_DAWN_LENGTH_KEY, Math.round(button.value));
         }));
 
-        this.w.attach(label, 0, 4, 1, 1);
-        this.w.attach(length, 1, 4, 1, 1);
+        this.w.attach(label, 0, 6, 1, 1);
+        this.w.attach(length, 1, 6, 1, 1);
 
 
         let label = new Gtk.Label({label: _("Source of sunset/sunrise time:"),
@@ -102,8 +134,8 @@ const RedshiftWidget = new Lang.Class({
             this._settings.set_enum(Lib.TIME_SOURCE_KEY, id);
         }));
 
-        this.w.attach(label, 0, 5, 1, 1);
-        this.w.attach(timesrc, 1, 5, 1, 1);
+        this.w.attach(label, 0, 7, 1, 1);
+        this.w.attach(timesrc, 1, 7, 1, 1);
 
 
         function format_time(time) {
@@ -142,8 +174,8 @@ const RedshiftWidget = new Lang.Class({
             }
         }));
 
-        this.w.attach(label, 0, 6, 1, 1);
-        this.w.attach(time, 1, 6, 1, 1);
+        this.w.attach(label, 0, 8, 1, 1);
+        this.w.attach(time, 1, 8, 1, 1);
 
 
         let label = new Gtk.Label({label: _("Time of sunset in fixed mode (hh:mm):"),
@@ -161,8 +193,8 @@ const RedshiftWidget = new Lang.Class({
             }
         }));
 
-        this.w.attach(label, 0, 7, 1, 1);
-        this.w.attach(time, 1, 7, 1, 1);
+        this.w.attach(label, 0, 9, 1, 1);
+        this.w.attach(time, 1, 9, 1, 1);
 
    },
 

--- a/redshift@benjamin.sipsolutions.net/schemas/org.gnome.shell.extensions.redshift-gnome.gschema.xml
+++ b/redshift@benjamin.sipsolutions.net/schemas/org.gnome.shell.extensions.redshift-gnome.gschema.xml
@@ -69,5 +69,17 @@
         <summary>Fixed time of sunset (seconds after midnight)</summary>
         <description>The time of the simulated sunset when in fixed time mode. The setting is given as seconds after midnight.</description>
     </key>
+    <key type="d" name="day-brightness">
+        <default>1.0</default>
+        <range min="0.0" max="1.0" />
+        <summary>The displays brightness by day</summary>
+        <description>The displays brightness by day. The default is 1.0.</description>
+    </key>
+    <key type="d" name="night-brightness">
+        <default>1.0</default>
+        <range min="0.0" max="1.0" />
+        <summary>The displays brightness by night</summary>
+        <description></description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Added a brightness variable to the gamma calculation, based on the formula used in the original redshift. As I did not also add a gamma variable, I assume this to be 1, which simplifies the equation to a few multiplications.

Added day and night brightness settings to the extension preferences.

Included patches for gnome 3.22 as currently included, as well as the most recent commit to master (as of a few days ago).